### PR TITLE
improving how saga arguments are passed

### DIFF
--- a/packages/redux-toolbelt-saga/CHANGELOG.md
+++ b/packages/redux-toolbelt-saga/CHANGELOG.md
@@ -1,0 +1,28 @@
+## v1.1.0 (2017-10-08)
+
+### Breaking Change
+Previously, when `makeAsyncSaga` was created it specified the arguments it will pass to the function it wraps:
+```js
+// this ** IS NOT! ** how it works now
+const saga = makeAsyncSaga(fetchTodosAction, fetchTodosFromServer, arg1, arg2, ...)
+```
+- Now, the default arguments passed to the function will be the action's payload.
+
+- Now, the only valid argument after the first two is `options`,
+and it includes two ways of mapping the arguments that are passed to the promise: `args` or `mapArgs`.
+
+```js
+// this IS how it works now
+const saga = makeAsyncSaga(fetchTodosAction, fetchTodosFromServer, {
+  args: [arg1, arg2],
+  //OR
+  mapArgs: function* (action){
+    const state = yield select()
+    return [action.payload.arg1, state.arg2]
+  },
+})
+```
+
+## v1.0.10
+
+Stable version

--- a/packages/redux-toolbelt-saga/README.md
+++ b/packages/redux-toolbelt-saga/README.md
@@ -47,13 +47,37 @@ Creates a saga that handles actions created using `makeAsyncActionCreator`.
 
 The first argument specifies saga when to dispatch the function in the second argument.
 
-Other arguments are passed to the function when it is run.
-
 ```js
 const fetchTodos = makeAsyncActionCreator('FETCH_TODOS')
 
 // Returns promise
-const fetchTodosFromServer = () => {/*...*/}
+const fetchTodosFromServer = ({id, url}, debug = false) => {/*...*/}
 
 const saga = makeAsyncSaga(fetchTodos, fetchTodosFromServer)
+
+//...
+dispatch(fetchTodos({id: 100, url: 'http://google.com'}))
+```
+
+By default, the payload of the action is what passed to the function as it's argument.
+
+You have two ways of changing it, using `options`:
+
+```js
+const options = {
+  // pass specific arguments
+  args: [{id, url}],
+  
+  // OR
+  
+  // map the action to arguments using a regular or a generator function
+  mapArgs: function* mapArgs(action){
+    const {todosId} = action.payload
+    const url = yield select(urlSelector)
+    
+    return [{id: todosId, url}, true]
+  }
+}
+
+const saga = makeAsyncSaga(fetchTodos, fetchTodosFromServer, options)
 ```

--- a/packages/redux-toolbelt-saga/src/makeAsyncSaga.js
+++ b/packages/redux-toolbelt-saga/src/makeAsyncSaga.js
@@ -3,10 +3,18 @@ import { call, put, takeLatest } from 'redux-saga/effects'
 /**
  * @param {AsyncActionCreator} asyncActionCreator
  * @param {function} fn
- * @param {...*} [args]
+ * @param options? = {mapArgs?, args?})
+ *
+ * @returns {Function}
  */
-export default function makeAsyncSaga(asyncActionCreator, fn, ...args){
-  function* exec(){
+export default function makeAsyncSaga(asyncActionCreator, fn, options = {}){
+  function* exec(action){
+
+    const args = yield getArgs(action, options)
+    if(!Array.isArray(args)){
+      throw new Error(`makeAsyncSaga expected an array of args, instead got: ${args}`)
+    }
+
     try {
       const result = yield call(fn, ...args)
       yield put(asyncActionCreator.success(result))
@@ -21,4 +29,21 @@ export default function makeAsyncSaga(asyncActionCreator, fn, ...args){
   }
 
   return waitFor
+}
+
+
+function* getArgs(action, options){
+  if (options.mapArgs){
+    return yield options.mapArgs(action)
+  }
+
+  if (options.args){
+    return options.args
+  }
+
+  if (action.payload){
+    return [action.payload]
+  }
+
+  return []
 }

--- a/packages/redux-toolbelt-saga/test/makeAsyncSaga.js
+++ b/packages/redux-toolbelt-saga/test/makeAsyncSaga.js
@@ -1,62 +1,145 @@
 import 'babel-polyfill'
 
-import {makeAsyncActionCreator} from '../../redux-toolbelt/src'
-import {makeAsyncSaga} from '../src'
+import { makeAsyncActionCreator } from '../../redux-toolbelt/src'
+import { makeAsyncSaga } from '../src'
+
+import { select } from 'redux-saga/effects'
 
 import createSagaMiddleware from 'redux-saga'
 import configureMockStore from 'redux-mock-store'
 
-function createStoreForTest(mySaga) {
+function createStoreForTest(mySaga, initialState = {}) {
   const sagaMiddleware = createSagaMiddleware()
   const mockStore = configureMockStore([sagaMiddleware])
-  const store = mockStore()
+  const store = mockStore(initialState)
   sagaMiddleware.run(mySaga)
   return store
 }
 
-function mockRequest({shouldReject = false} = {}){
-  return Promise.resolve().then(() => {
-    if(shouldReject){
-      throw 'some error'
+function mockRequest(...args){
+  return new Promise((resolve, reject) => {
+    if(args[0] === 'fail'){
+      reject('failed!')
     }
-    return { 'dummy': 'object' }
+    else{
+      resolve(args)
+    }
   })
 }
 
-test('saga dispatches success actions for a successful request', done => {
+describe('saga dispatches success actions for a successful request', () => {
+  test('with no args', done => {
+    const requestActionCreator = makeAsyncActionCreator('REQUEST')
+    const mySaga = makeAsyncSaga(requestActionCreator, mockRequest)
 
+    const store = createStoreForTest(mySaga)
+    store.dispatch(requestActionCreator())
+
+    setImmediate(() => {
+      const actualActions = store.getActions()
+      expect(actualActions).toEqual([
+        requestActionCreator(),
+        requestActionCreator.success([]),
+      ])
+      done()
+    })
+  })
+
+  test('with args', done => {
+    const requestActionCreator = makeAsyncActionCreator('REQUEST')
+    const mySaga = makeAsyncSaga(requestActionCreator, mockRequest)
+
+    const store = createStoreForTest(mySaga)
+    store.dispatch(requestActionCreator('some-arg'))
+
+    setImmediate(() => {
+      const actualActions = store.getActions()
+      expect(actualActions).toEqual([
+        requestActionCreator('some-arg'),
+        requestActionCreator.success(['some-arg']),
+      ])
+      done()
+    })
+  })
+
+  test('with pre-set args', done => {
+    const requestActionCreator = makeAsyncActionCreator('REQUEST')
+    const mySaga = makeAsyncSaga(requestActionCreator, mockRequest, {
+      args: ['preset-arg'],
+    })
+
+    const store = createStoreForTest(mySaga)
+    store.dispatch(requestActionCreator('some-arg'))
+
+    setImmediate(() => {
+      const actualActions = store.getActions()
+      expect(actualActions).toEqual([
+        requestActionCreator('some-arg'),
+        requestActionCreator.success(['preset-arg']),
+      ])
+      done()
+    })
+  })
+
+  test('with simple args mapping', done => {
+    const requestActionCreator = makeAsyncActionCreator('REQUEST')
+    const mySaga = makeAsyncSaga(requestActionCreator, mockRequest, {
+      mapArgs: () => ['mapped-arg'],
+    })
+
+    const store = createStoreForTest(mySaga)
+    store.dispatch(requestActionCreator('some-arg'))
+
+    setImmediate(() => {
+      const actualActions = store.getActions()
+      expect(actualActions).toEqual([
+        requestActionCreator('some-arg'),
+        requestActionCreator.success(['mapped-arg']),
+      ])
+      done()
+    })
+  })
+
+  test('with complex args mapping', done => {
+    const initialState = {
+      arg0: 'arg0',
+    }
+
+    const requestActionCreator = makeAsyncActionCreator('REQUEST')
+    const mySaga = makeAsyncSaga(requestActionCreator, mockRequest, {
+      mapArgs: function* (action){
+        const state = yield select()
+        return [state.arg0, action.payload.arg1]
+      },
+    })
+
+    const store = createStoreForTest(mySaga, initialState)
+    store.dispatch(requestActionCreator({arg1: 'arg1'}))
+
+    setImmediate(() => {
+      const actualActions = store.getActions()
+      expect(actualActions).toEqual([
+        requestActionCreator({arg1: 'arg1'}),
+        requestActionCreator.success(['arg0', 'arg1']),
+      ])
+      done()
+    })
+  })
+})
+
+test('saga dispatches failure actions for a failed request', done => {
   const requestActionCreator = makeAsyncActionCreator('REQUEST')
   const mySaga = makeAsyncSaga(requestActionCreator, mockRequest)
 
   const store = createStoreForTest(mySaga)
-  store.dispatch(requestActionCreator())
+  store.dispatch(requestActionCreator('fail'))
 
-  setTimeout(() => {
-    expect(store.getActions()).toEqual([
-      requestActionCreator(),
-      requestActionCreator.success({ 'dummy': 'object' }),
+  setImmediate(() => {
+    const actualActions = store.getActions()
+    expect(actualActions).toEqual([
+      requestActionCreator('fail'),
+      requestActionCreator.failure('failed!'),
     ])
-
     done()
   })
-
-})
-
-test('saga dispatches failure actions for a successful request', done => {
-
-  const requestActionCreator = makeAsyncActionCreator('REQUEST')
-  const mySaga = makeAsyncSaga(requestActionCreator, mockRequest, {shouldReject: true})
-
-  const store = createStoreForTest(mySaga)
-  store.dispatch(requestActionCreator())
-
-  setTimeout(() => {
-    expect(store.getActions()).toEqual([
-      requestActionCreator(),
-      requestActionCreator.failure('some error'),
-    ])
-
-    done()
-  })
-
 })


### PR DESCRIPTION
after this change we can do
```
makeAsyncSaga(loadCustomers, fetchCustomers)
```
and then
put(loadCustomers(userName))

will call `fetchCustomers` with the argument "userName" as well.

it is a breaking change since before that fetchCustomers would have been called without arguments.