### PR TITLE
Make reducer multiple actions

### DIFF
--- a/packages/redux-toolbelt-saga/test/makeAsyncSaga.js
+++ b/packages/redux-toolbelt-saga/test/makeAsyncSaga.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill'
-
 import { makeAsyncActionCreator } from '../../redux-toolbelt/src'
 import { makeAsyncSaga } from '../src'
 

--- a/packages/redux-toolbelt-thunk/src/makeThunkAsyncActionCreator.js
+++ b/packages/redux-toolbelt-thunk/src/makeThunkAsyncActionCreator.js
@@ -1,4 +1,4 @@
-import { makeAsyncActionCreator } from 'redux-toolbelt'
+import makeAsyncActionCreator from '../../redux-toolbelt/src/makeAsyncActionCreator'
 
 /**
  * Create an async action creator that relies on redux-thunk

--- a/packages/redux-toolbelt-thunk/test/makeThunkAsyncActionCreator.js
+++ b/packages/redux-toolbelt-thunk/test/makeThunkAsyncActionCreator.js
@@ -1,4 +1,6 @@
 import makeAsyncThunkActionCreator from '../src/makeThunkAsyncActionCreator'
+import isActionCreator from '../../redux-toolbelt/src/utils/isActionCreator'
+
 import configureMockStore from 'redux-mock-store'
 // import { applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
@@ -15,14 +17,23 @@ test('Creates actions with all expected type info and sub action', () => {
   expect(actionCreatorA.TYPE).toBe('A@ASYNC_REQUEST')
   expect(actionCreatorB.TYPE).toBe('B@ASYNC_REQUEST')
   expect(actionCreatorC.TYPE).toBe('C@ASYNC_REQUEST')
+  expect(isActionCreator(actionCreatorA)).toBe(true)
+  expect(isActionCreator(actionCreatorB)).toBe(true)
+  expect(isActionCreator(actionCreatorC)).toBe(true)
 
   expect(actionCreatorA.success.TYPE).toBe('A@ASYNC_SUCCESS')
   expect(actionCreatorB.success.TYPE).toBe('B@ASYNC_SUCCESS')
   expect(actionCreatorC.success.TYPE).toBe('C@ASYNC_SUCCESS')
+  expect(isActionCreator(actionCreatorA.success)).toBe(true)
+  expect(isActionCreator(actionCreatorB.success)).toBe(true)
+  expect(isActionCreator(actionCreatorC.success)).toBe(true)
 
   expect(actionCreatorA.failure.TYPE).toBe('A@ASYNC_FAILURE')
   expect(actionCreatorB.failure.TYPE).toBe('B@ASYNC_FAILURE')
   expect(actionCreatorC.failure.TYPE).toBe('C@ASYNC_FAILURE')
+  expect(isActionCreator(actionCreatorA.failure)).toBe(true)
+  expect(isActionCreator(actionCreatorB.failure)).toBe(true)
+  expect(isActionCreator(actionCreatorC.failure)).toBe(true)
 })
 
 test('Creates actions that calls the async function and passes params', () => {

--- a/packages/redux-toolbelt/README.md
+++ b/packages/redux-toolbelt/README.md
@@ -183,32 +183,88 @@ decrease()
 ```
 
 ### `makeReducer()`
-Creates a reducer that handles action created with `makeActionCreator()`.
+Creates a reducer that handles action creator[s] created with `makeActionCreator`.
 
-The second parameter is the handler of the specified action.
-
-If it is not supplied, the reducer will always return the payload of the action.
-
-The last parameter (second or third) is options.
-
-It can only have one option right now: `defaultState` that specifies the initial state. It is `null` by default.
-
+- The first argument is `actionCreator[s]` and it can be one of the following:
+  - `actionCreator`
+  - An array of `actionCreator`s 
+  - An object of `actionCreator`s
+    - *note: You can pass action creators as the keys of an object as such
+      because they are converted to strings as part of JS specification.
+      If you want to be extra cautious, you can pass the types of the action creators
+      instead the action creators themselves.*
+- The second argument is the `handler` for the specified action.
+  - If not specified, the reducer will update the state to
+    the payload of the action whenever it is fired.
+- The last argument is `options` and it is optional. It currently receives only parameter:
+  - `defaultState`: Specifies the initial state. It is `null` by default.
+ 
 ```
 const toggle = makeActionCreator('TOGGLE')
 
 const visibilityState = makeReducer(toggleActionCreatora, visible => !visible, {defaultState: true})
 
-const state1 = reducer(undefined, {TYPE: '@@redux/INIT'})
-// state1 === true
+let state = reducer(undefined, {TYPE: '@@redux/INIT'})
+// state === true
 
-const state2 = reducer(state1, toggle())
-// state2 === false
+state = reducer(state, toggle())
+// state === false
 
-const state3 = reducer(state2, toggle())
-// state3 === true
+state = reducer(state, toggle())
+// state === true
+```
+
+Using an actions object:
+
+```
+const increaseBy = makeActionCreator('INCREASE_BY')
+const decreaseBy = makeActionCreator('DECREASE_BY')
+
+// notice how passing an action creator is equivalent
+// to passing the action creator's type.
+
+const reducer = makeReducer({
+  [increaseBy]: (state, {payload}) => state + payload,
+  [decreaseBy.TYPE]: (state, {payload}) => state - payload,
+}, { defaultState: 100 })
+
+let state = reducer(undefined, {type: '@@redux/INIT'})
+// state === 100
+
+state = reducer(state, increaseBy(10))
+// state === 110
+
+state = reducer(state, decreaseBy(20))
+// state === 90
+```
+
+Passing multiple action creators as the first argument:
+
+```
+const increaseBy = makeActionCreator('INCREASE_BY')
+const decreaseBy = makeActionCreator('DECREASE_BY')
+
+const countUpdatedReducer = makeReducer(
+  [increaseBy, decreaseBy],
+  (state, {payload}) => (state || (payload !== 0)),
+  { defaultState: false }
+})
+
+let state = countUpdatedReducer(undefined, {type: '@@redux/INIT'})
+// state === false
+
+state = countUpdatedReducer(state, increaseBy(0))
+// state === false
+
+state = countUpdatedReducer(state, decreaseBy(20))
+// state === true
+
+state = countUpdatedReducer(state, increaseBy(20))
+// state === true
 ```
 
 It is very useful with `composeReducers`:
+
 ```
 const setUserName = makeActionCreator('SET_USER_NAME')
 const toggleShow = makeActionCreator('TOGGLE_SHOW')

--- a/packages/redux-toolbelt/package.json
+++ b/packages/redux-toolbelt/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/welldone-software/redux-toolbelt#readme",
   "dependencies": {
     "lodash.isfunction": "^3.0.8",
-    "lodash.isplainobject": "^4.0.6"
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.transform": "^4.6.0"
   }
 }

--- a/packages/redux-toolbelt/src/index.js
+++ b/packages/redux-toolbelt/src/index.js
@@ -6,3 +6,4 @@ export makeAsyncActionCreator from './makeAsyncActionCreator'
 export * from './makeAsyncActionCreator'
 export makeAsyncReducer from './makeAsyncReducer'
 
+export * from './utils'

--- a/packages/redux-toolbelt/src/makeActionCreator.js
+++ b/packages/redux-toolbelt/src/makeActionCreator.js
@@ -1,5 +1,5 @@
 import trivialArgsMapper from './_trivialArgsMapper'
-import {has, ownKeys} from './_objectUtils'
+import { has, ownKeys } from './_objectUtils'
 
 /**
  * @typedef {function(*, *): {type: string, payload: *, meta: *}} ActionCreator
@@ -45,9 +45,9 @@ export default function makeActionCreator(name, argsMapper = trivialArgsMapper, 
   }
 
   actionCreator.TYPE = type
+  actionCreator.toString = () => type
 
   return actionCreator
-
 }
 
 makeActionCreator.withDefaults = ({ prefix = '', defaultMeta }) => (baseName, argsMapper, options) => {

--- a/packages/redux-toolbelt/src/makeReducer.js
+++ b/packages/redux-toolbelt/src/makeReducer.js
@@ -1,39 +1,63 @@
 import isFunction from 'lodash.isfunction'
 import isPlainObject from 'lodash.isplainobject'
+import transform from 'lodash.transform'
+import isActionCreator from './utils/isActionCreator'
 
 const defaultOptions = {
   defaultState: null,
 }
 
-const defaultFunc = (state, action) => action.payload
+const defaultActionHandler = (state, action) => action.payload
 
 /**
- * makeReducer - makes a trivial reducer that returns the payload as the state
+ * makeReducer - makes a reducer that handles action creator[s]
  *
- * @param {ActionCreator|ActionCreator[]} actionCreators - aa action creator or an array of created with
- *                                        makeActionCreator (or part of a makeAsyncActionCreator)
- * @param {function(state,payload)|Object} [funcOrOptions] - function to be called when reducer's action is dispatched
+ * @param {ActionCreator|ActionCreator[]|Object} actionCreators - action creator or an array of action creators or an object of action creators
+ * @param {function(state,payload)|Object} [actionHandlerOrOptions] - function to be called when the specified actions are dispatched
  * @param {Object} [options] - specify reducer's options
- * @param [options.defaultState] - specify the initial (default) state
+ * @param {Object} [options.defaultState] - specify the initial (default) state
  */
-export default function makeReducer(actionCreators, funcOrOptions, options) {
-  const func = isFunction(funcOrOptions) ? funcOrOptions : defaultFunc
+// eslint-disable-next-line no-unused-vars
+export default function makeReducer(actionCreators, actionHandlerOrOptions, options) {
+  const actionsMap = getActionsMapFromArgs(arguments)
+  const { defaultState } = getOptions(arguments)
 
-  options = isPlainObject(funcOrOptions) ? funcOrOptions : options
-
-  options = options ? {
-    ...defaultOptions,
-    ...options,
-  } : defaultOptions
-
-  const {defaultState} = options
-
-  const types = (Array.isArray(actionCreators) ? actionCreators : [actionCreators]).map(({TYPE}) => TYPE)
-
-  return function (state = defaultState, action) {
-    if (types.indexOf(action.type) > -1) {
-      return func(state, action)
-    }
-    return state
+  return (state = defaultState, action) => {
+    const actionHandler = actionsMap[action.type]
+    return actionHandler ? actionHandler(state, action) : state
   }
+}
+
+function getActionsMapFromArgs(args){
+  if(Array.isArray(args[0])){
+    const actionCreators = args[0]
+    const actionsHandler = isFunction(args[1]) ? args[1] : defaultActionHandler
+
+    return transform(actionCreators, (actions, actionCreator) => {
+      actions[actionCreator.TYPE] = actionsHandler
+    }, {} )
+  }
+
+  if(isPlainObject(args[0])){
+    return args[0]
+  }
+
+  if(isActionCreator(args[0])){
+    const actionCreator = args[0]
+    const actionsHandler = isFunction(args[1]) ? args[1] : defaultActionHandler
+    return { [actionCreator]: actionsHandler }
+  }
+
+  throw new Error('[redux-toolbelt] makeReducer received an unexpected input.')
+}
+
+function getOptions(args){
+  if(args.length < 2){
+    return { ...defaultOptions }
+  }
+
+  const lastArg = args[args.length - 1]
+  return isPlainObject(lastArg) ?
+    { ...defaultOptions, ...lastArg } :
+    { ...defaultOptions }
 }

--- a/packages/redux-toolbelt/src/utils/index.js
+++ b/packages/redux-toolbelt/src/utils/index.js
@@ -1,0 +1,1 @@
+export isActionCreator from './isActionCreator'

--- a/packages/redux-toolbelt/src/utils/isActionCreator.js
+++ b/packages/redux-toolbelt/src/utils/isActionCreator.js
@@ -1,0 +1,7 @@
+const isActionCreator = obj => !!(
+  typeof(obj) === 'function' &&
+  obj.TYPE &&
+  obj.TYPE === obj.toString()
+)
+
+export default isActionCreator

--- a/packages/redux-toolbelt/test/makeActionCreator.js
+++ b/packages/redux-toolbelt/test/makeActionCreator.js
@@ -1,30 +1,26 @@
-import {makeActionCreator} from '../src'
+import {makeActionCreator, isActionCreator} from '../src'
 
 
 test('type is assigned', () => {
-
   const a = makeActionCreator('A')
 
   expect(a.TYPE).toBe('A')
-
 })
 
-
 test('no mapping', () => {
-
   const a = makeActionCreator('A')
 
+  expect(isActionCreator(a)).toBe(true)
   expect(a()).toEqual({type: 'A', payload: undefined, meta: undefined})
   expect(a(undefined, 'm')).toEqual({type: 'A', payload: undefined, meta: 'm'})
   expect(a('p')).toEqual({type: 'A', payload: 'p', meta: undefined})
   expect(a('p', 'm')).toEqual({type: 'A', payload: 'p', meta: 'm'})
-
 })
 
 test('short mapping', () => {
-
   const a = makeActionCreator('A', x => ({x}))
 
+  expect(isActionCreator(a)).toBe(true)
   expect(a()).toEqual({type: 'A', payload: {x: undefined}, meta: undefined})
   expect(a(4)).toEqual({type: 'A', payload: {x: 4}, meta: undefined})
   expect(a({y: '5'})).toEqual({type: 'A', payload: {x: {y: '5'} }, meta: undefined})
@@ -32,73 +28,73 @@ test('short mapping', () => {
 })
 
 test('full mapping, payload and meta', () => {
-
   const a = makeActionCreator('A', x => ({payload: x, meta: x}))
   const b = makeActionCreator('B', x => ({payload: x, meta: undefined}))
   const c = makeActionCreator('C', x => ({payload: undefined, meta: x}))
 
+  expect(isActionCreator(a)).toBe(true)
   expect(a()).toEqual({type: 'A', payload: undefined, meta: undefined})
   expect(a(4)).toEqual({type: 'A', payload: 4, meta: 4})
   expect(a({y: '5'})).toEqual({type: 'A', payload: {y: '5'}, meta: {y: '5'}})
 
+  expect(isActionCreator(b)).toBe(true)
   expect(b()).toEqual({type: 'B', payload: undefined, meta: undefined})
   expect(b(4)).toEqual({type: 'B', payload: 4, meta: undefined})
   expect(b({y: '5'})).toEqual({type: 'B', payload: {y: '5'}, meta: undefined})
 
+  expect(isActionCreator(c)).toBe(true)
   expect(c()).toEqual({type: 'C', payload: undefined, meta: undefined})
   expect(c(4)).toEqual({type: 'C', payload: undefined, meta: 4})
   expect(c({y: '5'})).toEqual({type: 'C', payload: undefined, meta: {y: '5'}})
 
 })
 
-
 test('full mapping, missing meta/payload fails', () => {
-
   const a = makeActionCreator('A', x => ({payload: x}))
   const b = makeActionCreator('B', x => ({meta: x}))
 
+  expect(isActionCreator(a)).toBe(true)
   expect(() => a()).toThrow()
   expect(() => a(4)).toThrow()
   expect(() => a({y: '5'})).toThrow()
 
+  expect(isActionCreator(b)).toBe(true)
   expect(() => b()).toThrow()
   expect(() => b(4)).toThrow()
   expect(() => b({y: '5'})).toThrow()
 })
 
-
 test('withDefaults prefix', () => {
-
   const myMakeActionCreator = makeActionCreator.withDefaults({prefix: 'x@'})
 
   const a = myMakeActionCreator('A')
   const b = myMakeActionCreator('B', z => ({z}))
   const c = myMakeActionCreator('C', z => ({payload: z, meta: z}))
 
+  expect(isActionCreator(a)).toBe(true)
   expect(a()).toEqual({type: 'x@A', payload: undefined, meta: undefined})
 
+  expect(isActionCreator(b)).toBe(true)
   expect(b()).toEqual({type: 'x@B', payload: {z: undefined}, meta: undefined})
 
+  expect(isActionCreator(c)).toBe(true)
   expect(c()).toEqual({type: 'x@C', payload: undefined, meta: undefined})
 })
 
-
 test('withDefaults defaultMeta', () => {
-
   const myMakeActionCreator = makeActionCreator.withDefaults({defaultMeta: {opt: 1}})
 
   const a = myMakeActionCreator('A')
   const b = myMakeActionCreator('B', z => ({z}))
   const c = myMakeActionCreator('C', z => ({payload: z, meta: z}))
 
+  expect(isActionCreator(a)).toBe(true)
   expect(a()).toEqual({type: 'A', payload: undefined, meta: {opt: 1}})
 
+  expect(isActionCreator(b)).toBe(true)
   expect(b()).toEqual({type: 'B', payload: {z: undefined}, meta: {opt: 1}})
 
+  expect(isActionCreator(c)).toBe(true)
   expect(c()).toEqual({type: 'C', payload: undefined, meta: {opt: 1}})
-
   expect(c({x: 2})).toEqual({type: 'C', payload: {x: 2}, meta: {opt: 1, x: 2}})
-
 })
-
-

--- a/packages/redux-toolbelt/test/makeAsyncActionCreator.js
+++ b/packages/redux-toolbelt/test/makeAsyncActionCreator.js
@@ -1,4 +1,4 @@
-import {makeAsyncActionCreator} from '../src'
+import {makeAsyncActionCreator, isActionCreator} from '../src'
 
 test('type assignment with naming conventions', () => {
 
@@ -6,14 +6,23 @@ test('type assignment with naming conventions', () => {
   const b = makeAsyncActionCreator('B', x => ({x}))
   const c = makeAsyncActionCreator('C', x => ({payload: x, meta: x}))
 
+  expect(isActionCreator(a)).toBe(true)
+  expect(isActionCreator(b)).toBe(true)
+  expect(isActionCreator(c)).toBe(true)
   expect(a.TYPE).toBe('A@ASYNC_REQUEST')
   expect(b.TYPE).toBe('B@ASYNC_REQUEST')
   expect(c.TYPE).toBe('C@ASYNC_REQUEST')
 
+  expect(isActionCreator(a.success)).toBe(true)
+  expect(isActionCreator(b.success)).toBe(true)
+  expect(isActionCreator(c.success)).toBe(true)
   expect(a.success.TYPE).toBe('A@ASYNC_SUCCESS')
   expect(b.success.TYPE).toBe('B@ASYNC_SUCCESS')
   expect(c.success.TYPE).toBe('C@ASYNC_SUCCESS')
 
+  expect(isActionCreator(a.failure)).toBe(true)
+  expect(isActionCreator(b.failure)).toBe(true)
+  expect(isActionCreator(c.failure)).toBe(true)
   expect(a.failure.TYPE).toBe('A@ASYNC_FAILURE')
   expect(b.failure.TYPE).toBe('B@ASYNC_FAILURE')
   expect(c.failure.TYPE).toBe('C@ASYNC_FAILURE')
@@ -24,6 +33,10 @@ test('args mapping is working for main (request) action', () => {
   const a = makeAsyncActionCreator('A')
   const b = makeAsyncActionCreator('B', x => ({x}))
   const c = makeAsyncActionCreator('C', x => ({payload: x, meta: x}))
+
+  expect(isActionCreator(a)).toBe(true)
+  expect(isActionCreator(b)).toBe(true)
+  expect(isActionCreator(c)).toBe(true)
 
   expect(a()).toEqual({type: 'A@ASYNC_REQUEST', payload: undefined, meta: undefined})
   expect(a(undefined, 'm')).toEqual({type: 'A@ASYNC_REQUEST', payload: undefined, meta: 'm'})
@@ -50,6 +63,7 @@ test('child (success and failure) actions always use trivial args mapping', () =
   const childActions = ['success', 'failure']
 
   actionCreators.forEach(function(a) {
+    expect(isActionCreator(a)).toBe(true)
     childActions.forEach(function(c){
       const type = a.TYPE.replace('REQUEST', c.toUpperCase())
       expect(a[c]()).toEqual({type, payload: undefined, meta: undefined})

--- a/packages/redux-toolbelt/test/makeReducer.js
+++ b/packages/redux-toolbelt/test/makeReducer.js
@@ -1,7 +1,6 @@
 import { makeReducer, makeActionCreator } from '../src'
 
 test('trivial', () => {
-
   const a = makeActionCreator('A')
 
   const reducer = makeReducer(a)
@@ -11,25 +10,7 @@ test('trivial', () => {
   expect(state).toEqual('test')
 })
 
-
-test('multiple creators', () => {
-
-  const a = makeActionCreator('A')
-  const b = makeActionCreator('B')
-  const c = makeActionCreator('C')
-
-  const reducer = makeReducer([a, b, c])
-
-  let state = reducer({}, a('a test'))
-  expect(state).toEqual('a test')
-  state = reducer({}, b('b test'))
-  expect(state).toEqual('b test')
-  state = reducer({}, c('c test'))
-  expect(state).toEqual('c test')
-})
-
 test('default state', () => {
-
   const a = makeActionCreator('A')
 
   const reducer = makeReducer(a, { defaultState: false })
@@ -40,7 +21,6 @@ test('default state', () => {
 })
 
 test('function', () => {
-
   const a = makeActionCreator('A')
 
   const reducer = makeReducer(a, (state, { payload }) => `${state}->${payload}`)
@@ -66,8 +46,8 @@ test('multiple actions handling', () => {
   const decreaseBy = makeActionCreator('DECREASE_BY')
 
   const reducer = makeReducer({
-    [increaseBy]: (state, { payload }) => state + payload,
-    [decreaseBy]: (state, { payload }) => state - payload,
+    [increaseBy]: (state, {payload}) => state + payload,
+    [decreaseBy.TYPE]: (state, {payload}) => state - payload,
   }, { defaultState: 100 })
 
   let state = reducer(undefined, { type: '@@redux/INIT' })

--- a/packages/redux-toolbelt/test/makeReducer.js
+++ b/packages/redux-toolbelt/test/makeReducer.js
@@ -1,4 +1,4 @@
-import {makeReducer, makeActionCreator} from '../src'
+import { makeReducer, makeActionCreator } from '../src'
 
 test('trivial', () => {
 
@@ -32,19 +32,18 @@ test('default state', () => {
 
   const a = makeActionCreator('A')
 
-  const reducer = makeReducer(a, {defaultState: false})
+  const reducer = makeReducer(a, { defaultState: false })
 
-  const state = reducer(undefined, {TYPE: 'something'})
+  const state = reducer(undefined, { TYPE: 'something' })
 
   expect(state).toEqual(false)
 })
-
 
 test('function', () => {
 
   const a = makeActionCreator('A')
 
-  const reducer = makeReducer(a, (state, {payload}) => `${state}->${payload}`)
+  const reducer = makeReducer(a, (state, { payload }) => `${state}->${payload}`)
 
   const state = reducer('initial', a('test'))
 
@@ -56,8 +55,56 @@ test('function and default state', () => {
 
   const reducer = makeReducer(a, state => !state)
 
-  const state1 = reducer(undefined, {TYPE: '@@redux/INIT'})
+  const state1 = reducer(undefined, { TYPE: '@@redux/INIT' })
   const state2 = reducer(state1, a())
 
   expect(state2).toEqual(true)
+})
+
+test('multiple actions handling', () => {
+  const increaseBy = makeActionCreator('INCREASE_BY')
+  const decreaseBy = makeActionCreator('DECREASE_BY')
+
+  const reducer = makeReducer({
+    [increaseBy]: (state, { payload }) => state + payload,
+    [decreaseBy]: (state, { payload }) => state - payload,
+  }, { defaultState: 100 })
+
+  let state = reducer(undefined, { type: '@@redux/INIT' })
+  expect(state).toEqual(100)
+
+  state = reducer(state, increaseBy(10))
+  expect(state).toEqual(110)
+
+  state = reducer(state, decreaseBy(20))
+  expect(state).toEqual(90)
+
+  state = reducer(state, { type: 'RANDOM_ACTION' })
+  expect(state).toEqual(90)
+})
+
+test('multiple creators', () => {
+  const increaseBy = makeActionCreator('INCREASE_BY')
+  const decreaseBy = makeActionCreator('DECREASE_BY')
+
+  const countUpdatedReducer = makeReducer(
+    [increaseBy, decreaseBy],
+    (state, { payload }) => state || payload !== 0,
+    { defaultState: false }
+  )
+
+  let state = countUpdatedReducer(undefined, { type: '@@redux/INIT' })
+  expect(state).toEqual(false)
+
+  state = countUpdatedReducer(state, increaseBy(0))
+  expect(state).toEqual(false)
+
+  state = countUpdatedReducer(state, decreaseBy(20))
+  expect(state).toEqual(true)
+
+  state = countUpdatedReducer(state, increaseBy(20))
+  expect(state).toEqual(true)
+
+  state = countUpdatedReducer(state, increaseBy(0))
+  expect(state).toEqual(true)
 })

--- a/packages/redux-toolbelt/test/utils/isActionCreator.js
+++ b/packages/redux-toolbelt/test/utils/isActionCreator.js
@@ -1,0 +1,54 @@
+import { isActionCreator, makeAsyncActionCreator, makeActionCreator } from '../../src'
+
+test('action creator is identified', () => {
+  const a = makeActionCreator('A')
+  expect(isActionCreator(a)).toEqual(true)
+})
+
+test('async action creator is identified', () => {
+  const a = makeAsyncActionCreator('A')
+
+  expect(isActionCreator(a)).toEqual(true)
+  expect(isActionCreator(a.success)).toEqual(true)
+  expect(isActionCreator(a.failure)).toEqual(true)
+  expect(isActionCreator(a.progress)).toEqual(true)
+  expect(isActionCreator(a.cancel)).toEqual(true)
+})
+
+test('simple function is not an action creator', () => {
+  const funcs = [
+    function(){
+      return 'bar'
+    },
+    function foo(){
+      return 'bar'
+    },
+    () => 'bar',
+  ]
+
+  funcs.forEach(func => {
+    expect(isActionCreator(func)).toEqual(false)
+  })
+})
+
+test('an object is not an action creator', () => {
+  const objs = [
+    {},
+    new Object(),
+    {
+      TYPE: 'type',
+    },
+    {
+      toString: () => 'type',
+    },
+    {
+      TYPE: 'type',
+      toString: () => 'type',
+    },
+  ]
+
+  objs.forEach(obj => {
+    expect(isActionCreator(obj)).toEqual(false)
+  })
+})
+

--- a/packages/redux-toolbelt/yarn.lock
+++ b/packages/redux-toolbelt/yarn.lock
@@ -9,3 +9,7 @@ lodash.isfunction@^3.0.8:
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.transform@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"


### PR DESCRIPTION
added a new makeReducer api that looks like this:
```js
const reducer = makeReducer({
  defaultState: 100,
  actions: {
    [increaseBy.TYPE]: (state, {payload}) => state + payload,
    [decreaseBy.TYPE]: (state, {payload}) => state - payload,
  },
})
```

also improved the readme and tests of this one:
```
const countUpdatedReducer = makeReducer(
  [increaseBy, decreaseBy],
  (state, {payload}) => (state || (payload !== 0)),
  { defaultState: false }
})
```