### PR TITLE
added two new options to makeAsync reducer:

### DIFF
--- a/packages/redux-toolbelt/src/makeAsyncReducer.js
+++ b/packages/redux-toolbelt/src/makeAsyncReducer.js
@@ -41,8 +41,11 @@ export default function makeAsyncReducer(actionCreator, options) {
       case actionCreator.progress.TYPE:
         return {...state, progress: payload}
       case actionCreator.failure.TYPE:  
-        return { ...(options.shouldDestroyDataOnError ? [] : state), loading: false, 
-          error: options.shouldSetError ? payload : undefined }
+        return { 
+          ...(options.shouldDestroyDataOnError ? {} : state), 
+          loading: false, 
+          error: options.shouldSetError ? payload : undefined 
+        }
       default:
         return state
     }

--- a/packages/redux-toolbelt/src/makeAsyncReducer.js
+++ b/packages/redux-toolbelt/src/makeAsyncReducer.js
@@ -8,6 +8,8 @@ export default function makeAsyncReducer(actionCreator, options) {
   const defaults = {
     dataProp: 'data',
     shouldDestroyData: true,
+    shouldDestroyDataOnError: true,
+    shouldSetError: true,
     defaultData: undefined,
     shouldSpread: false,
     shouldSetData: true,
@@ -38,8 +40,9 @@ export default function makeAsyncReducer(actionCreator, options) {
       }
       case actionCreator.progress.TYPE:
         return {...state, progress: payload}
-      case actionCreator.failure.TYPE:
-        return { loading: false, error: payload }
+      case actionCreator.failure.TYPE:  
+        return { ...(options.shouldDestroyDataOnError ? [] : state), loading: false, 
+          error: options.shouldSetError ? payload : undefined }
       default:
         return state
     }


### PR DESCRIPTION
shouldDestroyDataOnError {bool} - if true, we do not persist the current state data if an async operation returns an error
shouldSetError {bool} - if true, we store the error information (payload) in the state when an async error occurs