### PR TITLE
Immutable helpers 24 - add without update

### DIFF
--- a/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
@@ -3,11 +3,12 @@ import isMatch from 'lodash.ismatch'
 import defaultIdSelector from './defaultIdSelector'
 
 // upsertItemsById(arr, [{id: 'id_1', prop: 3, prop2: 'val'}])
-// upsertItemsById(arr, [{id: 'id_1', prop: 3, prop2: 'val'}], item => item.id)
+// upsertItemsById(arr, [{name: 'id_1', prop: 3, prop2: 'val'}], item => item.name)
 export default function upsertItemsById(arr, updatedItems, idSelector = defaultIdSelector) {
   if (!updatedItems || updatedItems.length === 0) {
     return arr || EMPTY_ARRAY
   }
+
   if (!arr) {
     return updatedItems || EMPTY_ARRAY
   }
@@ -16,7 +17,6 @@ export default function upsertItemsById(arr, updatedItems, idSelector = defaultI
 
   const updatedItemsMap = new Map(updatedItems.map(item => [idSelector(item), item]))
 
-  let hasChanges = false
   const result = arr.map(item => {
     const itemId = idSelector(item)
     if (!updatedItemsMap.has(itemId)) {
@@ -27,10 +27,13 @@ export default function upsertItemsById(arr, updatedItems, idSelector = defaultI
     if (isMatch(item, updatedItem)) {
       return item
     }
-    hasChanges = true
     return {...item, ...updatedItem}
   })
-  updatedItemsMap.forEach(item => result.push(item))
 
-  return hasChanges ? result : arr
+  if (updatedItemsMap.size === 0) {
+    return arr
+  }
+
+  updatedItemsMap.forEach(item => result.push(item))
+  return result
 }

--- a/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
@@ -9,11 +9,11 @@ export default function upsertItemsById(arr, updatedItems, idSelector = defaultI
     return arr || EMPTY_ARRAY
   }
 
+  updatedItems = Array.isArray(updatedItems) ? updatedItems : [updatedItems]
+
   if (!arr) {
     return updatedItems || EMPTY_ARRAY
   }
-
-  updatedItems = Array.isArray(updatedItems) ? updatedItems : [updatedItems]
 
   const updatedItemsMap = new Map(updatedItems.map(item => [idSelector(item), item]))
 

--- a/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
@@ -8,8 +8,40 @@ test('upsertItemsById', () => {
     {id: 4, val: 1},
   ])
 
-  const result = upsertItemsById(arr, [{id: 2, val: 6}, {id: 3, val: 9}, {id: 5, val: 16}])
-  const expected = [{id: 1, val: 2}, {id: 2, val: 6}, {id: 3, val: 9}, {id: 4, val: 1}, {id: 5, val: 16}]
+  const result = upsertItemsById(arr, [
+    {id: 2, val: 6},
+    {id: 3, val: 9},
+    {id: 5, val: 16},
+  ])
+  const expected = [
+    {id: 1, val: 2},
+    {id: 2, val: 6},
+    {id: 3, val: 9},
+    {id: 4, val: 1},
+    {id: 5, val: 16},
+  ]
+
+  expect(result).toEqual(expected)
+})
+
+test('upsertItemsById add items without updates', () => {
+  const arr = Object.freeze([
+    {id: 1, val: 2},
+    {id: 2, val: 5},
+    {id: 3, val: 8},
+    {id: 4, val: 1},
+  ])
+
+  const result = upsertItemsById(arr, [
+    {id: 5, val: 16},
+  ])
+  const expected = [
+    {id: 1, val: 2},
+    {id: 2, val: 5},
+    {id: 3, val: 8},
+    {id: 4, val: 1},
+    {id: 5, val: 16},
+  ]
 
   expect(result).toEqual(expected)
 })

--- a/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
@@ -13,6 +13,7 @@ test('upsertItemsById', () => {
     {id: 3, val: 9},
     {id: 5, val: 16},
   ])
+  
   const expected = [
     {id: 1, val: 2},
     {id: 2, val: 6},
@@ -35,6 +36,7 @@ test('upsertItemsById add items without updates', () => {
   const result = upsertItemsById(arr, [
     {id: 5, val: 16},
   ])
+
   const expected = [
     {id: 1, val: 2},
     {id: 2, val: 5},

--- a/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/test/upsertItemsById.js
@@ -45,3 +45,26 @@ test('upsertItemsById add items without updates', () => {
 
   expect(result).toEqual(expected)
 })
+
+test('upsertItemsById add item to invalid array', () => {
+  const arr = Object.freeze(null)
+  const result = upsertItemsById(arr, {id: 5, val: 16})
+  const expected = [{id: 5, val: 16}]
+  expect(result).toEqual(expected)
+})
+
+test('upsertItemsById add array of items to an empty array', () => {
+  const arr = Object.freeze([])
+  
+  const result = upsertItemsById(arr, [
+    {id: 4, val: 1},
+    {id: 5, val: 16},
+  ])
+
+  const expected = [
+    {id: 4, val: 1},
+    {id: 5, val: 16},
+  ]
+
+  expect(result).toEqual(expected)
+})


### PR DESCRIPTION
Added tests and/or implemented the following cases:

* Adding to a non-empty array without updating existing values (see #24)
* Adding to empty or invalid arrays

Closes #24 