### PR TITLE
Drops unnecessary dependency on yarn in favor of npm, always available.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,5 @@
 {
   "lerna": "2.0.0-rc.5",
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent",
-  "npmClient": "yarn"
+  "packages": ["packages/*"],
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test:watch": "npm test --watch",
     "test": "cross-env NODE_ENV=test jest --no-cache --runInBand",
     "lint": "eslint packages/*/src/**/*.js packages/*/test/**/*.js",
-    "lint:fix": "yarn lint --fix",
-    "prepublish": "yarn lint && yarn test && yarn build",
+    "lint:fix": "npm lint --fix",
+    "prepublish": "npm run lint && npm test && npm run build",
     "install": "lerna bootstrap",
     "clean": "lerna clean --yes && rimraf ./packages/*/lib node_modules",
     "generateToc": "node scripts/generateToc.js"


### PR DESCRIPTION
To make wider distribution easier, once downloaded, it is good manners that a package should not fail on the `npm i` command. 

Making implicit dependencies on globally installed packages (thus not present in the dependencies lists of `package.json`) is not a good idea, specially when there is no real need.

Partially fixes #30 