### PR TITLE
Fix the bug when upserting items without any Added items. It'll retur…

### DIFF
--- a/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
+++ b/packages/redux-toolbelt-immutable-helpers/src/upsertItemsById.js
@@ -31,7 +31,7 @@ export default function upsertItemsById(arr, updatedItems, idSelector = defaultI
   })
 
   if (updatedItemsMap.size === 0) {
-    return arr
+    return result
   }
 
   updatedItemsMap.forEach(item => result.push(item))


### PR DESCRIPTION
Fix the bug when upserting items without any Added items. It'll return original array. Return the new composed array instead