### PR TITLE
Cancel action - implementation

### DIFF
--- a/packages/redux-toolbelt-observable/src/makeAsyncEpic.js
+++ b/packages/redux-toolbelt-observable/src/makeAsyncEpic.js
@@ -1,6 +1,6 @@
 import { from, throwError, of } from 'rxjs'
 import { ofType } from 'redux-observable'
-import { mergeMap, switchMap, map, catchError } from 'rxjs/operators'
+import { mergeMap, switchMap, map, catchError, takeUntil } from 'rxjs/operators'
 
 export default function makeAsyncEpic(actionCreator, asyncFn, {cancelPreviousFunctionCalls = false} = {}) {
   const mapFunction = cancelPreviousFunctionCalls ? switchMap : mergeMap
@@ -23,6 +23,7 @@ export default function makeAsyncEpic(actionCreator, asyncFn, {cancelPreviousFun
         const meta = { ...origMeta, _toolbeltAsyncFnArgs: payload }
 
         return obs.pipe(
+          takeUntil(action$.ofType(actionCreator.cancel.TYPE)),
           map(payload => actionCreator.success(payload, meta)),
           catchError(error => of(actionCreator.failure(error, meta))),
         )

--- a/packages/redux-toolbelt-observable/test/makeAsyncEpic.js
+++ b/packages/redux-toolbelt-observable/test/makeAsyncEpic.js
@@ -144,3 +144,26 @@ test('Dispatches few success actions for resolved promises and cancel previous r
     done()
   })
 })
+
+test('Dispatches actions for resolved promises and cancel requests', done => {
+  const store = createStoreForTest(() => Promise.resolve(5))
+  store.dispatch(actionCreator({a: true}))
+  store.dispatch(actionCreator({b: true}))
+  store.dispatch(actionCreator.cancel())
+  
+  const actions = store.getActions()
+
+  setImmediate(() => {
+    expect(actions[0].type).toBe(actionCreator.TYPE)
+    expect(actions[0].payload).toEqual({a: true})
+
+    expect(actions[1].type).toBe(actionCreator.TYPE)
+    expect(actions[1].payload).toEqual({b: true})
+
+    expect(actions[2].type).toBe(actionCreator.cancel.TYPE)
+
+    expect(actions).toHaveLength(3)
+
+    done()
+  })
+})


### PR DESCRIPTION
An implementation to cancel an action before success/failure

```
fetchTodos()
fetchTodos.cancel()
```