### PR TITLE
Support redux-observable 2.0.0 - replacing action$.ofType() with pipeable operator

### DIFF
--- a/packages/redux-toolbelt-observable/src/makeAsyncEpic.js
+++ b/packages/redux-toolbelt-observable/src/makeAsyncEpic.js
@@ -23,7 +23,7 @@ export default function makeAsyncEpic(actionCreator, asyncFn, {ignoreOlderParall
         const meta = { ...origMeta, _toolbeltAsyncFnArgs: payload }
 
         return obs.pipe(
-          takeUntil(action$.ofType(actionCreator.cancel.TYPE)),
+          takeUntil(action$.pipe(ofType(actionCreator.cancel.TYPE))),
           map(payload => actionCreator.success(payload, meta)),
           catchError(error => of(actionCreator.failure(error, meta))),
         )


### PR DESCRIPTION
https://redux-observable.js.org/CHANGELOG.html